### PR TITLE
Add openai and cognitive search private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Following links are available:
 - `privatelink.azuredatabricks.net`
 - `privatelink.batch.azure.com`
 - `privatelink.database.windows.net`
+- `privatelink.openai.azure.com`
+- `privatelink.cognitiveservices.azure.com`
 
 ### Service Suffix
 

--- a/locals.tf
+++ b/locals.tf
@@ -33,6 +33,8 @@ locals {
       "privatelink.azuredatabricks.net"           = "privatelink.databricks.azure.us",
       "privatelink.batch.azure.com"               = "privatelink.batch.usgovcloudapi.net",
       "privatelink.database.windows.net"          = "privatelink.database.usgovcloudapi.net"
+      "privatelink.openai.azure.com"              = "privatelink.openai.azure.us",
+      "privatelink.cognitiveservices.azure.com"   = "privatelink.cognitiveservices.azure.us"
 
     }
     public = {
@@ -68,7 +70,8 @@ locals {
       "privatelink.azuredatabricks.net"           = "privatelink.azuredatabricks.net",
       "privatelink.batch.azure.com"               = "privatelink.batch.azure.com",
       "privatelink.database.windows.net"          = "privatelink.database.windows.net"
-
+      "privatelink.openai.azure.com"              = "privatelink.openai.azure.com",
+      "privatelink.cognitiveservices.azure.com"   = "privatelink.cognitiveservices.azure.com"
     }
   }
   suffixes = {


### PR DESCRIPTION
On the back of picking up some work for adding OpenAI to AzureTRE, I realised there was still an open issue for adding the privatelinks for OpenAI and Cognitive Search. 

Source for the US private links: https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure

Resolves #13 