### PR TITLE
Fabric Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Following links are available:
 - `privatelink.database.windows.net`
 - `privatelink.openai.azure.com`
 - `privatelink.cognitiveservices.azure.com`
-- `privatelink.pbidedicated.windows.net`
-- `privatelink.analysis.windows.net`
-- `privatelink.prod.powerquery.microsoft.com`
+- `privatelink.pbidedicated.windows.net` This link is supported only in public regions.
+- `privatelink.analysis.windows.net` This link is supported only in public regions.
+- `privatelink.prod.powerquery.microsoft.com` This link is supported only in public regions.
 
 
 ### Service Suffix

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+### Reference for Private Link Configurations
+
+For detailed DNS mappings and configurations of private endpoints across environments (Public, US Government, China, Germany), refer to the official [Azure Private Link Documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns). 
+
+The documentation includes:
+- Private DNS zone configurations
+- Supported resource types and regional availability
+- Environment-specific guidelines (Public, US Government, China, Germany)
+
+If you cannot find a specific private endpoint link in this repository, consult the documentation for the latest details.
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ### Reference for Private Link Configurations
 
-For detailed DNS mappings and configurations of private endpoints across environments (Public, US Government, China, Germany), refer to the official [Azure Private Link Documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns). 
+For detailed DNS mappings and configurations of private endpoints across environments (Public, US Government, China, Germany),
+refer to the official [Azure Private Link Documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns).
 
 The documentation includes:
 - Private DNS zone configurations

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Following links are available:
 - `privatelink.database.windows.net`
 - `privatelink.openai.azure.com`
 - `privatelink.cognitiveservices.azure.com`
+- `privatelink.pbidedicated.windows.net`
+- `privatelink.analysis.windows.net`
+- `privatelink.prod.powerquery.microsoft.com`
+
 
 ### Service Suffix
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,6 @@
 locals {
   private_links = {
     usgovernment = {
-      "privatelink.pbidedicated.windows.net"      = "privatelink.pbidedicated.windows.us",
-      "privatelink.analysis.windows.net"          = "privatelink.analysis.windows.us",
-      "privatelink.prod.powerquery.microsoft.com" = "privatelink.prod.powerquery.microsoft.us",
       "privatelink.azurewebsites.net"             = "privatelink.azurewebsites.us",
       "privatelink.queue.core.windows.net"        = "privatelink.queue.core.usgovcloudapi.net",
       "privatelink.table.core.windows.net"        = "privatelink.table.core.usgovcloudapi.net",

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,9 @@
 locals {
   private_links = {
     usgovernment = {
+      "privatelink.pbidedicated.windows.net"      = "privatelink.pbidedicated.windows.us",
+      "privatelink.analysis.windows.net"          = "privatelink.analysis.windows.us",
+      "privatelink.prod.powerquery.microsoft.com" = "privatelink.prod.powerquery.microsoft.us",
       "privatelink.azurewebsites.net"             = "privatelink.azurewebsites.us",
       "privatelink.queue.core.windows.net"        = "privatelink.queue.core.usgovcloudapi.net",
       "privatelink.table.core.windows.net"        = "privatelink.table.core.usgovcloudapi.net",
@@ -38,6 +41,9 @@ locals {
 
     }
     public = {
+      "privatelink.pbidedicated.windows.net"      = "privatelink.pbidedicated.windows.net",
+      "privatelink.analysis.windows.net"          = "privatelink.analysis.windows.net",
+      "privatelink.prod.powerquery.microsoft.com" = "privatelink.prod.powerquery.microsoft.com",
       "privatelink.azurewebsites.net"             = "privatelink.azurewebsites.net",
       "privatelink.queue.core.windows.net"        = "privatelink.queue.core.windows.net",
       "privatelink.table.core.windows.net"        = "privatelink.table.core.windows.net",


### PR DESCRIPTION
### Updated PR Summary:

This pull request enhances the `README.md` and `locals.tf` files with the following changes:

#### Updates to `README.md`:
- Added new private link entries: 
  - `privatelink.pbidedicated.windows.net`
  - `privatelink.analysis.windows.net`
  - `privatelink.prod.powerquery.microsoft.com`
- Included a reference section with a link to the official [[Azure Private Link Documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns)](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns) to assist in finding environment-specific private link configurations.

#### Updates to `locals.tf`:
- Added mappings for:
  - `privatelink.pbidedicated.windows.net`
  - `privatelink.analysis.windows.net`
  - `privatelink.prod.powerquery.microsoft.com`  
  for the `usgovernment` configuration.
- Added the same mappings for the `public` configuration.

[Issue created for the US gov links that not found for fabric](https://github.com/microsoft/terraform-azurerm-environment-configuration/issues/22)